### PR TITLE
fix: Fixed the issue where a “reqwuest” client was being created with…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ pub mod routes;
 pub mod utils;
 
 use axum::{
-    Router, middleware as axum_middleware,
+    Router,
+    extract::FromRef,
+    middleware as axum_middleware,
     routing::{get, post},
 };
 use sqlx::PgPool;
@@ -28,11 +30,30 @@ use routes::proxy::proxy;
 use routes::system::quota_sync::sync_to_db;
 use std::sync::Arc;
 
+#[derive(Clone)]
+pub struct AppState {
+    pub pool: PgPool,
+    pub http_client: reqwest::Client,
+}
+
+impl FromRef<AppState> for PgPool {
+    fn from_ref(state: &AppState) -> PgPool {
+        state.pool.clone()
+    }
+}
+
+impl FromRef<AppState> for reqwest::Client {
+    fn from_ref(state: &AppState) -> reqwest::Client {
+        state.http_client.clone()
+    }
+}
+
 pub fn create_router(
     pool: PgPool,
     rate_limiter: Arc<dyn RateLimiter>,
     auth_cache: Arc<dyn AuthCache>,
     auth_cache_ttl_secs: u64,
+    http_client: reqwest::Client,
 ) -> Router {
     let protected_routes = Router::new()
         .route("/proxy/test", get(|| async { "ok" }))
@@ -69,5 +90,5 @@ pub fn create_router(
     public_routes
         .merge(protected_routes)
         .merge(system_routes)
-        .with_state(pool)
+        .with_state(AppState { pool, http_client })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,14 @@ async fn main() {
     }
 
     let port = std::env::var("API_PORT").unwrap_or_else(|_| "8080".to_string());
-    let app = create_router(pool, rate_limiter, valkey_auth_cache, ttl_seconds);
+    let http_client = reqwest::Client::new();
+    let app = create_router(
+        pool,
+        rate_limiter,
+        valkey_auth_cache,
+        ttl_seconds,
+        http_client,
+    );
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:".to_string() + &port)
         .await

--- a/src/routes/proxy.rs
+++ b/src/routes/proxy.rs
@@ -14,6 +14,7 @@ use sqlx::PgPool;
 // /proxy/{name}/{*rest_path} のリクエストを upstream_services の base_url に転送する
 pub async fn proxy(
     State(pool): State<PgPool>,
+    State(client): State<reqwest::Client>,
     Extension(authed): Extension<AuthedApiKey>,
     Path((name, rest_path)): Path<(String, String)>,
     request: Request,
@@ -62,8 +63,7 @@ pub async fn proxy(
         })?
         .to_bytes();
 
-    // reqwest で転送
-    let client = reqwest::Client::new();
+    // reqwest で転送（共有 Client を利用してコネクションプール / keep-alive を有効化）
     let mut req = client
         .request(to_reqwest_method(&method), &target_url)
         .body(body_bytes.to_vec());

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -38,6 +38,7 @@ async fn setup() -> (axum::Router, PgPool, Arc<dyn RateLimiter>) {
         rate_limiter.clone(),
         auth_cache,
         auth_cache_ttl_secs,
+        reqwest::Client::new(),
     );
     (app, pool, rate_limiter)
 }


### PR DESCRIPTION
## Summary / 概要

サーバー起動時にreqwest::Clientを一つだけ作る。
そのClientを引数でcreate_routerに渡す。
AxumのStateけいゆでproxyハンドラに配る

## Background / 背景 *

reqwest::Client は内部にコネクションプールを持っていて、一度開いた TCP/TLS 接続をプールに保持しておき、次のリクエストで再利用する（= HTTPkeep-alive）仕組みになっています。    
      
- 修正前: 毎リクエストで Client を新規作成 → プールが毎回空 →上流への接続を毎回張り直す（TCP ハンドシェイク、HTTPS なら TLSハンドシェイクも毎回発生）                     
-                              
- 修正後: 1 つの Client を全リクエストで共有 → プールに接続が溜まる → 2 回目以降は既存接続を使い回せる  

## Issue (or Discussion) Link / イシューまたはディスカッションのリンク
#64 

## Impact / 影響範囲

## Changes / 変更内容

## Testing / テスト*
- [ ] `cargo fmt && cargo clippy` pass with no warnings

## Checklist / セルフチェックリスト
- [ ] Updated relevant documentation (Wiki, comments, etc.) / 関連するドキュメント（Wikiやコメント）を更新した

## Screenshots or Video / スクリーンショット・動画

## Notes / 備考
